### PR TITLE
Fix: pip timeout

### DIFF
--- a/components/file-watcher/recipe.yaml
+++ b/components/file-watcher/recipe.yaml
@@ -36,7 +36,7 @@ Manifests:
     Lifecycle:
       Install:
         Timeout: 300
-        Script: python3 -m pip install -v -r {artifacts:decompressedPath}/file-watcher/requirements.txt
+        Script: python3 -m pip --timeout=120 install -v -r {artifacts:decompressedPath}/file-watcher/requirements.txt
       Run:
         Script: "python3 -u {artifacts:decompressedPath}/file-watcher/src/main.py"
     Artifacts:
@@ -47,7 +47,7 @@ Manifests:
     Lifecycle:
       Install:
         Timeout: 300
-        Script: python -m pip install -v -r {artifacts:decompressedPath}/file-watcher/requirements.txt
+        Script: python -m pip --timeout=120 install -v -r {artifacts:decompressedPath}/file-watcher/requirements.txt
       Run:
         Script: "python -u {artifacts:decompressedPath}/file-watcher/src/main.py"
     Artifacts:

--- a/components/opc-archiver/recipe.yaml
+++ b/components/opc-archiver/recipe.yaml
@@ -32,7 +32,7 @@ Manifests:
     Lifecycle:
       Install:
         Timeout: 300
-        Script: python3 -m pip install -v -r {artifacts:decompressedPath}/opc-archiver/requirements.txt
+        Script: python3 -m pip --timeout=120 install -v -r {artifacts:decompressedPath}/opc-archiver/requirements.txt
       Run:
         Script: "python3 -u {artifacts:decompressedPath}/opc-archiver/src/main.py"
     Artifacts:
@@ -43,7 +43,7 @@ Manifests:
     Lifecycle:
       Install:
         Timeout: 300
-        Script: python -m pip install -v -r {artifacts:decompressedPath}/opc-archiver/requirements.txt
+        Script: python -m pip --timeout=120 install -v -r {artifacts:decompressedPath}/opc-archiver/requirements.txt
       Run:
         Script: "python -u {artifacts:decompressedPath}/opc-archiver/src/main.py"
     Artifacts:

--- a/components/rdb-exporter/install.ps1
+++ b/components/rdb-exporter/install.ps1
@@ -35,4 +35,4 @@ java -jar $EMBULK_EXEC_PATH gem install embulk-output-s3
 java -jar $EMBULK_EXEC_PATH gem install liquid -v 4.0.0
 
 Write-Host "Installing python packages..."
-python -m pip install -v -r "$DECOMPRESSED_PATH\requirements.txt"
+python -m pip install --timeout=120 -v -r "$DECOMPRESSED_PATH\requirements.txt"

--- a/components/rdb-exporter/install.sh
+++ b/components/rdb-exporter/install.sh
@@ -27,4 +27,4 @@ java -jar ${EMBULK_EXEC_PATH} gem install liquid -v 4.0.0
 chmod +x ${DECOMPRESSED_PATH}/src/main.py
 
 echo "Installing python packages..."
-python3 -m pip install -v -r ${DECOMPRESSED_PATH}/requirements.txt
+python3 -m pip --timeout=120 install -v -r ${DECOMPRESSED_PATH}/requirements.txt


### PR DESCRIPTION
Extended the timeout setting because sometimes pip install times out due to network issues.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
